### PR TITLE
Add go mod version badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,6 +4,7 @@
 [![Tests](https://github.com/embano1/vsphere-alarm-server/actions/workflows/unit-test.yaml/badge.svg)](https://github.com/embano1/vsphere-alarm-server/actions/workflows/unit-test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/embano1/vsphere-alarm-server)](https://goreportcard.com/report/github.com/embano1/vsphere-alarm-server)
 [![codecov](https://codecov.io/gh/embano1/vsphere-alarm-server/branch/main/graph/badge.svg?token=TC7MW723JO)](https://codecov.io/gh/embano1/vsphere-alarm-server)
+[![go.mod Go version](https://img.shields.io/github/go-mod/go-version/embano1/vsphere-alarm-server)](https://github.com/embano1/vsphere-alarm-server)
 
 Reacting to vSphere
 [Alarms](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.monitoring.doc/GUID-79AC1262-D701-4BC8-8F8D-F046AE0578CF.html)


### PR DESCRIPTION
Closes: #10 

Note that due to using pre-releases a "release" badge as indicated in the issue cannot be created (linked to).

Signed-off-by: Michael Gasch <mgasch@vmware.com>